### PR TITLE
Add a switch to ensure URL is supporting HTTP Range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+.vscode/launch.json


### PR DESCRIPTION
Add `-r` switch. Now program will report error if target URL is not supporting HTTP range:

```
➜ cargo run -- -r list https://example.site/file.zip
//...
Error: Range request not supported
```

Related with #3