### PR TITLE
Update zip dep to v7

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install MSRV
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: 1.82.0
+            toolchain: 1.83.0
             override: true
             components: rustfmt, clippy
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MPL-2.0"
 name = "partialzip"
 readme = "README.md"
 repository = "https://github.com/marcograss/partialzip"
-rust-version = "1.82.0"
+rust-version = "1.83.0"
 version = "5.0.0"
 
 [features]
@@ -47,14 +47,14 @@ num-traits = "0.2.19"
 serde = { version = "1.0.219", features = ["derive"] }
 thiserror = "2.0.12"
 url = "2.5.4"
-zip = {version = "1", default-features = false, features = ["bzip2", "deflate", "zstd"]}
+zip = {version = "7", default-features = false, features = ["bzip2", "deflate", "zstd"]}
 
 [dev-dependencies]
 actix-files = "0.6.6"
 actix-web = {version = "4.11.0", default-features = false, features = []}
 anyhow = "1.0.98"
 assert_cmd = "2.0.17"
-criterion = "0.6.0"
+criterion = "0.7.0"
 predicates = "3.1.3"
 tempfile = "3.20.0"
 tokio = {version = "1.46.1", features = ["macros", "rt-multi-thread"]}

--- a/src/partzip.rs
+++ b/src/partzip.rs
@@ -165,16 +165,22 @@ impl PartialZip {
                             | zip::CompressionMethod::Bzip2
                             | zip::CompressionMethod::Zstd
                     );
-                    let date = NaiveDate::from_ymd_opt(
-                        file.last_modified().year().into(),
-                        file.last_modified().month().into(),
-                        file.last_modified().day().into(),
-                    );
-                    let time = NaiveTime::from_hms_opt(
-                        file.last_modified().hour().into(),
-                        file.last_modified().minute().into(),
-                        file.last_modified().second().into(),
-                    );
+                    let (date, time) = if let Some(datetime) = file.last_modified() {
+                        (
+                            NaiveDate::from_ymd_opt(
+                                datetime.year().into(),
+                                datetime.month().into(),
+                                datetime.day().into(),
+                            ),
+                            NaiveTime::from_hms_opt(
+                                datetime.hour().into(),
+                                datetime.minute().into(),
+                                datetime.second().into(),
+                            ),
+                        )
+                    } else {
+                        (None, None)
+                    };
                     let last_modified = if let (Some(d), Some(t)) = (date, time) {
                         Some(NaiveDateTime::new(d, t))
                     } else {


### PR DESCRIPTION
This required bumping MSRV to 1.83 to match zip's MSRV.

Also bump criterion to 0.7. Could also be bumped to 0.8, but then bench MSRV would be 1.86.