### PR TITLE
feat: add parallel downloads, glob matching, retry logic, JSON output, and reduce dependencies

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.83.0"
+          toolchain: "1.86.0"
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
       - name: Run cargo check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MPL-2.0"
 name = "partialzip"
 readme = "README.md"
 repository = "https://github.com/marcograss/partialzip"
-rust-version = "1.83.0"
+rust-version = "1.86.0"
 version = "6.0.0"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.83.0"
 version = "6.0.0"
 
 [features]
-cmdline = ["dep:anyhow", "dep:clap", "dep:env_logger"]
+cmdline = ["dep:anyhow", "dep:clap", "dep:env_logger", "dep:serde_json"]
 default = ["cmdline", "progressbar"]
 progressbar = ["dep:indicatif"]
 rustls = ["curl/rustls"]
@@ -38,13 +38,12 @@ anyhow = {version = "1.0.100", optional = true}
 bytesize = "2.3.1"
 chrono = { version = "0.4.43", features = ["serde"] }
 clap = {version = "4.5.54", features = ["derive"], optional = true}
-conv = "0.3.3"
 curl = {version = "0.4.49", default-features = false}
 env_logger = {version = "0.11.8", optional = true}
 indicatif = {version = "0.18.3", optional = true}
 log = "0.4.29"
-num-traits = "0.2.19"
 serde = { version = "1.0.228", features = ["derive"] }
+serde_json = {version = "1", optional = true}
 thiserror = "2.0.18"
 url = "2.5.8"
 zip = {version = "7", default-features = false, features = ["bzip2", "deflate", "zstd"]}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,26 @@ docker run --rm marcograss/partialzip list http://yoururl/file.ipsw
 # download piping to stdout and save it on the host
 docker run --rm marcograss/partialzip pipe http://yoururl/file.ipsw kernelcache.release.iphone10 > kernelcache.release.iphone10
 ```
+### Filtering and JSON output:
+```
+# filter files by glob pattern
+partialzip list --filter "*.txt" http://yoururl/file.zip
+# output as JSON (useful for scripting)
+partialzip list --json http://yoururl/file.zip
+# combine both
+partialzip list -d --json --filter "kernel*" http://yoururl/file.ipsw
+```
+
+### Authentication and proxy:
+```
+# basic authentication
+partialzip -u myuser -p mypass list http://yoururl/file.zip
+# via HTTP proxy
+partialzip --proxy http://proxy:8080 list http://yoururl/file.zip
+# via SOCKS5 proxy with authentication
+partialzip --proxy socks5://proxy:1080 --proxy-user user --proxy-pass pass list http://yoururl/file.zip
+```
+
 ## What is used for
 
 Sometimes zip archives are huge and you just need a couple of files, for example, a kernelcache from an ipsw
@@ -60,6 +80,56 @@ cargo run -- -r list http://yoururl/yourfile.zip
 ## How to use as a library
 If you want to use partialzip as a library and you want to reduce the binary size, you can choose in your `Cargo.toml` the flag `default-features = false` in the partialzip dependency.
 This will not build the command line of partialzip which is not required to use it as a library, and it will avoid including some unnecessary dependencies and save space.
+
+### Library features
+
+**Streaming to disk** (avoids loading entire files into memory):
+```rust
+use partialzip::PartialZip;
+use std::path::Path;
+
+let pz = PartialZip::new("https://example.com/archive.zip")?;
+pz.download_to_file("large_file.bin", Path::new("output.bin"))?;
+```
+
+**Glob pattern matching** (download files by pattern):
+```rust
+let pz = PartialZip::new("https://example.com/archive.zip")?;
+let txt_files = pz.download_matching("*.txt")?;
+// Or list matching filenames
+let names = pz.list_names_matching("kernel*");
+```
+
+**Parallel downloads** (multiple connections for faster batch downloads):
+```rust
+let pz = PartialZip::new("https://example.com/archive.zip")?;
+let results = pz.download_multiple_parallel(&["file1.txt", "file2.txt"], 4)?;
+```
+
+**Retry with exponential backoff** (resilience for flaky connections):
+```rust
+use partialzip::{PartialZip, PartialZipOptions};
+use std::time::Duration;
+
+let options = PartialZipOptions::new()
+    .max_retries(3)
+    .retry_base_delay(Duration::from_secs(1));
+let pz = PartialZip::new_with_options("https://example.com/archive.zip", &options)?;
+```
+
+**Configuration** (timeouts, authentication, proxy):
+```rust
+use partialzip::{PartialZip, PartialZipOptions};
+use std::time::Duration;
+
+let options = PartialZipOptions::new()
+    .max_redirects(5)
+    .connect_timeout(Some(Duration::from_secs(60)))
+    .check_range(true)
+    .basic_auth("user", "pass")
+    .proxy("http://proxy:8080");
+let pz = PartialZip::new_with_options("https://example.com/archive.zip", &options)?;
+```
 
 ## rustls
 You can avoid using openssl by enabling the `rustls` feature to avoid the dependency

--- a/src/bin/partialzip.rs
+++ b/src/bin/partialzip.rs
@@ -9,21 +9,51 @@ use std::time::Duration;
 use url::Url;
 
 /// Handler to list the files from command line
-fn list(url: &str, detailed: bool, options: &PartialZipOptions) -> Result<()> {
+fn list(
+    url: &str,
+    detailed: bool,
+    json: bool,
+    filter: Option<&str>,
+    options: &PartialZipOptions,
+) -> Result<()> {
     let url = Url::parse(url).context("invalid URL for listing")?;
     let pz = PartialZip::new_with_options(url.as_str(), options)
         .context("Cannot create PartialZip instance for listing")?;
     if detailed {
-        pz.list_detailed().into_iter().for_each(|f| {
+        let files = filter.map_or_else(
+            || pz.list_detailed(),
+            |pattern| pz.list_detailed_matching(pattern),
+        );
+        if json {
             println!(
-                "{} - {} - Supported: {}",
-                f.name,
-                ByteSize(f.compressed_size),
-                f.supported
+                "{}",
+                serde_json::to_string_pretty(&files).context("JSON serialization failed")?
             );
-        });
+        } else {
+            for f in files {
+                println!(
+                    "{} - {} - Supported: {}",
+                    f.name,
+                    ByteSize(f.compressed_size),
+                    f.supported
+                );
+            }
+        }
     } else {
-        pz.list_names().into_iter().for_each(|f| println!("{f}"));
+        let names = filter.map_or_else(
+            || pz.list_names(),
+            |pattern| pz.list_names_matching(pattern),
+        );
+        if json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&names).context("JSON serialization failed")?
+            );
+        } else {
+            for name in names {
+                println!("{name}");
+            }
+        }
     }
     Ok(())
 }
@@ -97,6 +127,12 @@ enum Commands {
         /// list file size and support not only names
         #[arg(short = 'd', long)]
         detailed: bool,
+        /// output as JSON
+        #[arg(short = 'j', long)]
+        json: bool,
+        /// filter filenames by glob pattern (e.g., "*.txt", "kernel*")
+        #[arg(short = 'f', long)]
+        filter: Option<String>,
         /// url of the zip file
         url: String,
     },
@@ -138,7 +174,12 @@ fn main() -> Result<()> {
     }
 
     match cli.command {
-        Commands::List { detailed, url } => list(&url, detailed, &options),
+        Commands::List {
+            detailed,
+            json,
+            filter,
+            url,
+        } => list(&url, detailed, json, filter.as_deref(), &options),
         Commands::Download {
             url,
             filename,

--- a/src/partzip.rs
+++ b/src/partzip.rs
@@ -1,9 +1,7 @@
 use chrono::NaiveDate;
 use chrono::NaiveDateTime;
 use chrono::NaiveTime;
-use conv::{NoError, ValueFrom};
 use curl::easy::Easy;
-use num_traits::ToPrimitive;
 use serde::Deserialize;
 use serde::Serialize;
 use std::cell::RefCell;
@@ -45,12 +43,6 @@ pub enum PartialZipError {
     /// Error for CURL
     #[error("CURL error: {0}")]
     CURLError(#[from] curl::Error),
-    /// `NoError` error
-    #[error("NoError error: {0}")]
-    NoError(#[from] NoError),
-    /// Conversion Error
-    #[error("Conversion error: {0}")]
-    ConvError(#[from] conv::PosOverflow<u64>),
 }
 
 /// Default maximum number of HTTP redirects to follow
@@ -84,6 +76,10 @@ pub struct PartialZipOptions {
     pub proxy: Option<String>,
     /// Proxy authentication credentials (username, password)
     pub proxy_auth: Option<(String, String)>,
+    /// Maximum number of retries for transient network errors (0 = no retries)
+    pub max_retries: u32,
+    /// Base delay between retries (doubles with each attempt for exponential backoff)
+    pub retry_base_delay: Duration,
 }
 
 impl Default for PartialZipOptions {
@@ -97,6 +93,8 @@ impl Default for PartialZipOptions {
             basic_auth: None,
             proxy: None,
             proxy_auth: None,
+            max_retries: 0,
+            retry_base_delay: Duration::from_secs(1),
         }
     }
 }
@@ -163,6 +161,20 @@ impl PartialZipOptions {
         self.proxy_auth = Some((username.to_string(), password.to_string()));
         self
     }
+
+    /// Set the maximum number of retries for transient network errors (0 = disabled)
+    #[must_use]
+    pub const fn max_retries(mut self, max: u32) -> Self {
+        self.max_retries = max;
+        self
+    }
+
+    /// Set the base delay between retries (doubles with each attempt for exponential backoff)
+    #[must_use]
+    pub const fn retry_base_delay(mut self, delay: Duration) -> Self {
+        self.retry_base_delay = delay;
+        self
+    }
 }
 
 /// Core struct of the crate representing a zip file we want to access partially
@@ -174,6 +186,8 @@ pub struct PartialZip {
     archive: RefCell<ZipArchive<BufReader<PartialReader>>>,
     /// The archive size
     file_size: u64,
+    /// Configuration options (stored for creating parallel connections)
+    options: PartialZipOptions,
 }
 
 /// Compression methods for the files inside the archive. Redefined structure to make it serializable.
@@ -253,6 +267,7 @@ impl PartialZip {
             url: url.to_owned(),
             archive: RefCell::new(archive),
             file_size,
+            options: options.clone(),
         })
     }
 
@@ -532,6 +547,174 @@ impl PartialZip {
         }
         Ok(total_bytes)
     }
+
+    /// Returns the options used to create this [`PartialZip`]
+    #[must_use]
+    pub const fn options(&self) -> &PartialZipOptions {
+        &self.options
+    }
+
+    /// Get a list of filenames matching a glob pattern (supports `*` and `?`)
+    pub fn list_names_matching(&self, pattern: &str) -> Vec<String> {
+        self.list_names()
+            .into_iter()
+            .filter(|name| super::utils::glob_match(pattern, name))
+            .collect()
+    }
+
+    /// Get a list of files with details matching a glob pattern (supports `*` and `?`)
+    pub fn list_detailed_matching(&self, pattern: &str) -> Vec<PartialZipFileDetailed> {
+        self.list_detailed()
+            .into_iter()
+            .filter(|f| super::utils::glob_match(pattern, &f.name))
+            .collect()
+    }
+
+    /// Download all files matching a glob pattern into memory.
+    ///
+    /// Returns a vector of tuples containing the filename and its content.
+    /// Pattern supports `*` (any sequence) and `?` (any single char).
+    ///
+    /// # Errors
+    /// Will return a [`PartialZipError`] on the first file that fails to download.
+    pub fn download_matching(
+        &self,
+        pattern: &str,
+    ) -> Result<Vec<(String, Vec<u8>)>, PartialZipError> {
+        let matching: Vec<String> = self.list_names_matching(pattern);
+        let refs: Vec<&str> = matching.iter().map(String::as_str).collect();
+        self.download_multiple(&refs)
+    }
+
+    /// Download all files matching a glob pattern to a directory.
+    ///
+    /// Pattern supports `*` (any sequence) and `?` (any single char).
+    /// Returns the total number of bytes written.
+    ///
+    /// # Errors
+    /// Will return a [`PartialZipError`] on the first file that fails to download.
+    pub fn download_matching_to_dir(
+        &self,
+        pattern: &str,
+        output_dir: &Path,
+    ) -> Result<u64, PartialZipError> {
+        let matching: Vec<String> = self.list_names_matching(pattern);
+        let refs: Vec<&str> = matching.iter().map(String::as_str).collect();
+        self.download_multiple_to_dir(&refs, output_dir)
+    }
+
+    /// Download multiple files in parallel using separate connections.
+    ///
+    /// Creates up to `max_concurrent` connections to the server and distributes
+    /// files across them. Each connection independently fetches and decompresses
+    /// its assigned files.
+    ///
+    /// Returns a vector of tuples containing the filename and its content.
+    /// Note: file order in the result may differ from the input order.
+    ///
+    /// # Errors
+    /// Will return a [`PartialZipError`] on the first file that fails to download.
+    pub fn download_multiple_parallel(
+        &self,
+        filenames: &[&str],
+        max_concurrent: usize,
+    ) -> Result<Vec<(String, Vec<u8>)>, PartialZipError> {
+        if filenames.is_empty() {
+            return Ok(Vec::new());
+        }
+        let url = &self.url;
+        let options = &self.options;
+        let max_concurrent = max_concurrent.max(1).min(filenames.len());
+
+        // Distribute files round-robin across workers
+        let mut chunks: Vec<Vec<&str>> = (0..max_concurrent).map(|_| Vec::new()).collect();
+        for (i, filename) in filenames.iter().enumerate() {
+            chunks[i % max_concurrent].push(filename);
+        }
+
+        std::thread::scope(|s| {
+            let handles: Vec<_> = chunks
+                .into_iter()
+                .filter(|c| !c.is_empty())
+                .map(|chunk| {
+                    s.spawn(move || -> Result<Vec<(String, Vec<u8>)>, PartialZipError> {
+                        let pz = Self::new_with_options(url, options)?;
+                        chunk
+                            .iter()
+                            .map(|filename| {
+                                let content = pz.download(filename)?;
+                                Ok(((*filename).to_string(), content))
+                            })
+                            .collect()
+                    })
+                })
+                .collect();
+
+            let mut all_results = Vec::with_capacity(filenames.len());
+            for handle in handles {
+                let results = handle.join().map_err(|_| {
+                    PartialZipError::IOError(io::Error::other("download thread panicked"))
+                })??;
+                all_results.extend(results);
+            }
+            Ok(all_results)
+        })
+    }
+
+    /// Download multiple files in parallel to a directory using separate connections.
+    ///
+    /// Creates up to `max_concurrent` connections and streams each file directly to disk.
+    /// Returns the total number of bytes written.
+    ///
+    /// # Errors
+    /// Will return a [`PartialZipError`] on the first file that fails to download.
+    pub fn download_multiple_to_dir_parallel(
+        &self,
+        filenames: &[&str],
+        output_dir: &Path,
+        max_concurrent: usize,
+    ) -> Result<u64, PartialZipError> {
+        if filenames.is_empty() {
+            return Ok(0);
+        }
+        let url = &self.url;
+        let options = &self.options;
+        let max_concurrent = max_concurrent.max(1).min(filenames.len());
+
+        let mut chunks: Vec<Vec<&str>> = (0..max_concurrent).map(|_| Vec::new()).collect();
+        for (i, filename) in filenames.iter().enumerate() {
+            chunks[i % max_concurrent].push(filename);
+        }
+
+        std::thread::scope(|s| {
+            let handles: Vec<_> = chunks
+                .into_iter()
+                .filter(|c| !c.is_empty())
+                .map(|chunk| {
+                    s.spawn(move || -> Result<u64, PartialZipError> {
+                        let pz = Self::new_with_options(url, options)?;
+                        let mut bytes = 0u64;
+                        for filename in &chunk {
+                            let output_name = Path::new(filename)
+                                .file_name()
+                                .unwrap_or_else(|| std::ffi::OsStr::new(filename));
+                            let output_path = output_dir.join(output_name);
+                            bytes += pz.download_to_file(filename, &output_path)?;
+                        }
+                        Ok(bytes)
+                    })
+                })
+                .collect();
+
+            let mut total_bytes = 0u64;
+            for handle in handles {
+                total_bytes += handle.join().map_err(|_| {
+                    PartialZipError::IOError(io::Error::other("download thread panicked"))
+                })??;
+            }
+            Ok(total_bytes)
+        })
+    }
 }
 
 /// Reader for the partialzip doing only the partial read instead of downloading everything
@@ -542,9 +725,23 @@ pub struct PartialReader {
     file_size: u64,
     easy: Easy,
     pos: u64,
+    max_retries: u32,
+    retry_base_delay: Duration,
 }
 
 const HTTP_PARTIAL_CONTENT: u32 = 206;
+
+/// Extract content length from a curl Easy handle as u64
+fn content_length_as_u64(easy: &mut Easy) -> Result<u64, PartialZipError> {
+    let len = easy.content_length_download()?;
+    if len >= 0.0 && len.is_finite() {
+        // Safety: we've verified len is non-negative and finite
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        Ok(len as u64)
+    } else {
+        Err(std::io::Error::new(ErrorKind::InvalidData, "invalid content length").into())
+    }
+}
 
 impl PartialReader {
     /// Creates a new [`PartialReader`] with default options
@@ -604,19 +801,14 @@ impl PartialReader {
         easy.nobody(true)?;
         easy.write_function(|data| Ok(data.len()))?;
         easy.perform()?;
-        let file_size = easy
-            .content_length_download()?
-            .to_u64()
-            .ok_or_else(|| std::io::Error::new(ErrorKind::InvalidData, "invalid content length"))?;
+        let file_size = content_length_as_u64(&mut easy)?;
 
         if options.check_range {
             // check if range-request is possible by request 1 byte. if 206 Partial Content (HTTP_PARTIAL_CONTENT) is returned, we can make future request.
             easy.range("0-0")?;
             easy.nobody(true)?;
             easy.perform()?;
-            let head_size = easy.content_length_download()?.to_u64().ok_or_else(|| {
-                std::io::Error::new(ErrorKind::InvalidData, "can not perform range request")
-            })?;
+            let head_size = content_length_as_u64(&mut easy)?;
             if head_size != 1 {
                 return Err(PartialZipError::RangeNotSupported);
             }
@@ -632,6 +824,8 @@ impl PartialReader {
             file_size,
             easy,
             pos: 0,
+            max_retries: options.max_retries,
+            retry_base_delay: options.retry_base_delay,
         })
     }
 
@@ -655,13 +849,9 @@ impl io::Read for PartialReader {
         // start = current position
         let start = self.pos;
         // end candidate = start + buf.len() - 1;
+        let buf_len = buf.len() as u64;
         let maybe_end = start
-            .checked_add(buf.len().to_u64().ok_or_else(|| {
-                std::io::Error::new(
-                    ErrorKind::InvalidData,
-                    format!("The buf len is invalid {}", buf.len()),
-                )
-            })?)
+            .checked_add(buf_len)
             .ok_or_else(|| {
                 std::io::Error::new(
                     ErrorKind::InvalidData,
@@ -700,33 +890,56 @@ impl io::Read for PartialReader {
         self.easy.range(&range)?;
         self.easy.get(true)?;
 
-        let mut content: Vec<u8> = Vec::new();
-        {
-            let mut transfer = self.easy.transfer();
-            transfer.write_function(|data| {
-                log::trace!("transfered {:x} bytes", data.len());
-                content.extend_from_slice(data);
-                Ok(data.len())
-            })?;
+        let max_attempts = self.max_retries + 1;
+        let mut last_error = None;
 
-            transfer.perform()?;
-        };
+        for attempt in 0..max_attempts {
+            if attempt > 0 {
+                let delay = self
+                    .retry_base_delay
+                    .saturating_mul(2u32.saturating_pow(attempt - 1));
+                log::warn!(
+                    "Retrying request (attempt {}/{max_attempts}) after {delay:?}",
+                    attempt + 1
+                );
+                std::thread::sleep(delay);
+            }
 
-        let n = io::Read::read(&mut content.as_slice(), buf)?;
-        // new position = position + read amount;
-        self.pos = self
-            .pos
-            .checked_add(n.to_u64().ok_or_else(|| {
-                std::io::Error::new(ErrorKind::InvalidData, format!("invalid read amount {n}"))
-            })?)
-            .ok_or_else(|| {
+            let mut content: Vec<u8> = Vec::new();
+            {
+                let mut transfer = self.easy.transfer();
+                transfer.write_function(|data| {
+                    log::trace!("transferred {:x} bytes", data.len());
+                    content.extend_from_slice(data);
+                    Ok(data.len())
+                })?;
+
+                match transfer.perform() {
+                    Ok(()) => {}
+                    Err(e) => {
+                        log::warn!("Request failed: {e}");
+                        last_error = Some(e);
+                        continue;
+                    }
+                }
+            }
+
+            let n = io::Read::read(&mut content.as_slice(), buf)?;
+            // new position = position + read amount;
+            self.pos = self.pos.checked_add(n as u64).ok_or_else(|| {
                 std::io::Error::new(
                     ErrorKind::InvalidData,
                     format!("adding {n} overflows the reader position {}", self.pos),
                 )
             })?;
-        log::trace!("new self.pos = {:x}", self.pos);
-        Ok(n)
+            log::trace!("new self.pos = {:x}", self.pos);
+            return Ok(n);
+        }
+
+        Err(io::Error::other(format!(
+            "request failed after {max_attempts} attempts: {}",
+            last_error.expect("at least one attempt was made")
+        )))
     }
 }
 
@@ -742,18 +955,13 @@ impl io::Seek for PartialReader {
             io::SeekFrom::Current(n) => (self.pos, n),
         };
         log::trace!("seek base_pos = {base_pos:x} offset = {offset:x}");
+        #[allow(clippy::cast_sign_loss)] // offset >= 0 is checked
         let new_pos = if offset >= 0 {
             // position = base position + offset
-            base_pos.checked_add(
-                u64::value_from(offset)
-                    .map_err(|e| std::io::Error::new(ErrorKind::InvalidData, e.to_string()))?,
-            )
+            base_pos.checked_add(offset as u64)
         } else {
-            // position = base position - offset
-            base_pos.checked_sub(
-                u64::value_from(offset.wrapping_neg())
-                    .map_err(|e| std::io::Error::new(ErrorKind::InvalidData, e.to_string()))?,
-            )
+            // position = base position - |offset|
+            base_pos.checked_sub(offset.unsigned_abs())
         };
         // check if new position is valid
         match new_pos {

--- a/src/partzip.rs
+++ b/src/partzip.rs
@@ -493,6 +493,26 @@ impl PartialZip {
             .collect()
     }
 
+    /// Check that filenames don't produce duplicate output basenames when written to a directory
+    fn check_duplicate_basenames(filenames: &[&str]) -> Result<(), PartialZipError> {
+        let mut seen = std::collections::HashSet::new();
+        for filename in filenames {
+            let basename = Path::new(filename)
+                .file_name()
+                .unwrap_or_else(|| std::ffi::OsStr::new(filename));
+            if !seen.insert(basename.to_owned()) {
+                return Err(PartialZipError::IOError(io::Error::new(
+                    ErrorKind::InvalidInput,
+                    format!(
+                        "duplicate output filename '{}' from archive entry '{filename}'",
+                        basename.to_string_lossy()
+                    ),
+                )));
+            }
+        }
+        Ok(())
+    }
+
     /// Download multiple files from the archive to a directory, streaming to disk.
     ///
     /// This method efficiently reuses the underlying connection for all downloads
@@ -504,12 +524,14 @@ impl PartialZip {
     /// Returns the total number of bytes written across all files.
     ///
     /// # Errors
-    /// Will return a [`PartialZipError`] on the first file that fails to download.
+    /// Will return a [`PartialZipError`] if any file fails to download or if multiple
+    /// archive entries would produce the same output filename.
     pub fn download_multiple_to_dir(
         &self,
         filenames: &[&str],
         output_dir: &Path,
     ) -> Result<u64, PartialZipError> {
+        Self::check_duplicate_basenames(filenames)?;
         let mut total_bytes = 0u64;
         for filename in filenames {
             // Extract just the filename component (handle paths in archive)
@@ -537,6 +559,7 @@ impl PartialZip {
         filenames: &[&str],
         output_dir: &Path,
     ) -> Result<u64, PartialZipError> {
+        Self::check_duplicate_basenames(filenames)?;
         let mut total_bytes = 0u64;
         for filename in filenames {
             let output_name = Path::new(filename)
@@ -677,6 +700,7 @@ impl PartialZip {
         if filenames.is_empty() {
             return Ok(0);
         }
+        Self::check_duplicate_basenames(filenames)?;
         let url = &self.url;
         let options = &self.options;
         let max_concurrent = max_concurrent.max(1).min(filenames.len());
@@ -838,6 +862,7 @@ impl PartialReader {
 
 impl io::Read for PartialReader {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        const MAX_RETRY_DELAY: Duration = Duration::from_secs(60);
         log::trace!(
             "read self.pos = {:x} self.file_size = {:x}",
             self.pos,
@@ -890,14 +915,15 @@ impl io::Read for PartialReader {
         self.easy.range(&range)?;
         self.easy.get(true)?;
 
-        let max_attempts = self.max_retries + 1;
+        let max_attempts = self.max_retries.saturating_add(1);
         let mut last_error = None;
 
         for attempt in 0..max_attempts {
             if attempt > 0 {
                 let delay = self
                     .retry_base_delay
-                    .saturating_mul(2u32.saturating_pow(attempt - 1));
+                    .saturating_mul(2u32.saturating_pow(attempt - 1))
+                    .min(MAX_RETRY_DELAY);
                 log::warn!(
                     "Retrying request (attempt {}/{max_attempts}) after {delay:?}",
                     attempt + 1

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -28,6 +28,41 @@ mod utils_tests {
             );
         }
     }
+
+    #[test]
+    /// Test glob pattern matching
+    pub fn glob_match_tests() {
+        // Exact match
+        assert!(crate::utils::glob_match("hello", "hello"));
+        assert!(!crate::utils::glob_match("hello", "world"));
+
+        // Star wildcard
+        assert!(crate::utils::glob_match("*.txt", "file.txt"));
+        assert!(crate::utils::glob_match("*.txt", ".txt"));
+        assert!(!crate::utils::glob_match("*.txt", "file.rs"));
+        assert!(crate::utils::glob_match("kernel*", "kernelcache.release"));
+        assert!(crate::utils::glob_match("*", "anything"));
+        assert!(crate::utils::glob_match("*", ""));
+
+        // Question mark wildcard
+        assert!(crate::utils::glob_match("?.txt", "1.txt"));
+        assert!(!crate::utils::glob_match("?.txt", "12.txt"));
+
+        // Combined patterns
+        assert!(crate::utils::glob_match(
+            "*.release.*",
+            "kernelcache.release.iphone10"
+        ));
+        assert!(crate::utils::glob_match(
+            "dir/*/file.txt",
+            "dir/sub/file.txt"
+        ));
+
+        // Edge cases
+        assert!(crate::utils::glob_match("", ""));
+        assert!(!crate::utils::glob_match("", "notempty"));
+        assert!(!crate::utils::glob_match("notempty", ""));
+    }
 }
 
 #[cfg(test)]
@@ -390,6 +425,8 @@ mod partzip_tests {
             Duration::from_secs(DEFAULT_TCP_KEEPINTVL_SECS)
         );
         assert_eq!(options.tcp_keepintvl, Duration::from_secs(60));
+        assert_eq!(options.max_retries, 0);
+        assert_eq!(options.retry_base_delay, Duration::from_secs(1));
     }
 
     #[test]
@@ -575,6 +612,163 @@ mod partzip_tests {
             assert_eq!(total_bytes, 10);
             assert!(temp_dir.path().join("1.txt").exists());
             assert!(temp_dir.path().join("2.txt").exists());
+            Ok(())
+        })
+        .await?
+    }
+
+    #[test]
+    /// Test that retry options builder methods work correctly
+    fn test_options_retry() {
+        let options = PartialZipOptions::new()
+            .max_retries(3)
+            .retry_base_delay(Duration::from_millis(500));
+        assert_eq!(options.max_retries, 3);
+        assert_eq!(options.retry_base_delay, Duration::from_millis(500));
+    }
+
+    #[tokio::test]
+    /// Test `list_names_matching` with glob patterns
+    async fn test_list_names_matching() -> Result<()> {
+        let address = spawn_server()?.address;
+        tokio::task::spawn_blocking(move || {
+            let pz = PartialZip::new(address.join("/files/test.zip")?.as_str())?;
+
+            let matched = pz.list_names_matching("*.txt");
+            assert_eq!(matched.len(), 2);
+
+            let matched = pz.list_names_matching("1.*");
+            assert_eq!(matched, vec!["1.txt".to_string()]);
+
+            let matched = pz.list_names_matching("?.txt");
+            assert_eq!(matched.len(), 2);
+
+            let matched = pz.list_names_matching("nope*");
+            assert!(matched.is_empty());
+
+            Ok(())
+        })
+        .await?
+    }
+
+    #[tokio::test]
+    /// Test `list_detailed_matching` with glob patterns
+    async fn test_list_detailed_matching() -> Result<()> {
+        let address = spawn_server()?.address;
+        tokio::task::spawn_blocking(move || {
+            let pz = PartialZip::new(address.join("/files/test.zip")?.as_str())?;
+
+            let matched = pz.list_detailed_matching("1.*");
+            assert_eq!(matched.len(), 1);
+            assert_eq!(matched[0].name, "1.txt");
+
+            let matched = pz.list_detailed_matching("*");
+            assert_eq!(matched.len(), 2);
+
+            Ok(())
+        })
+        .await?
+    }
+
+    #[tokio::test]
+    /// Test `download_matching` with glob patterns
+    async fn test_download_matching() -> Result<()> {
+        let address = spawn_server()?.address;
+        tokio::task::spawn_blocking(move || {
+            let pz = PartialZip::new(address.join("/files/test.zip")?.as_str())?;
+            let results = pz.download_matching("1.*")?;
+            assert_eq!(results.len(), 1);
+            assert_eq!(results[0].0, "1.txt");
+            assert_eq!(results[0].1, vec![0x41, 0x41, 0x41, 0x41, 0xa]);
+            Ok(())
+        })
+        .await?
+    }
+
+    #[tokio::test]
+    /// Test `download_matching_to_dir` with glob patterns
+    async fn test_download_matching_to_dir() -> Result<()> {
+        let address = spawn_server()?.address;
+        tokio::task::spawn_blocking(move || {
+            let pz = PartialZip::new(address.join("/files/test.zip")?.as_str())?;
+            let temp_dir = tempfile::tempdir()?;
+            let bytes = pz.download_matching_to_dir("*.txt", temp_dir.path())?;
+            assert_eq!(bytes, 10); // 5 bytes each
+            assert!(temp_dir.path().join("1.txt").exists());
+            assert!(temp_dir.path().join("2.txt").exists());
+            Ok(())
+        })
+        .await?
+    }
+
+    #[tokio::test]
+    /// Test parallel download of multiple files
+    async fn test_download_multiple_parallel() -> Result<()> {
+        let address = spawn_server()?.address;
+        tokio::task::spawn_blocking(move || {
+            let pz = PartialZip::new(address.join("/files/test.zip")?.as_str())?;
+            let results = pz.download_multiple_parallel(&["1.txt", "2.txt"], 2)?;
+
+            assert_eq!(results.len(), 2);
+            // Files may come back in different order due to parallelism
+            let mut sorted = results;
+            sorted.sort_by(|a, b| a.0.cmp(&b.0));
+            assert_eq!(sorted[0].0, "1.txt");
+            assert_eq!(sorted[0].1, vec![0x41, 0x41, 0x41, 0x41, 0xa]);
+            assert_eq!(sorted[1].0, "2.txt");
+            assert_eq!(sorted[1].1, vec![0x42, 0x42, 0x42, 0x42, 0xa]);
+            Ok(())
+        })
+        .await?
+    }
+
+    #[tokio::test]
+    /// Test parallel download to a directory
+    async fn test_download_multiple_to_dir_parallel() -> Result<()> {
+        let address = spawn_server()?.address;
+        tokio::task::spawn_blocking(move || {
+            let pz = PartialZip::new(address.join("/files/test.zip")?.as_str())?;
+            let temp_dir = tempfile::tempdir()?;
+            let total_bytes =
+                pz.download_multiple_to_dir_parallel(&["1.txt", "2.txt"], temp_dir.path(), 2)?;
+
+            assert_eq!(total_bytes, 10);
+            assert_eq!(
+                std::fs::read(temp_dir.path().join("1.txt"))?,
+                vec![0x41, 0x41, 0x41, 0x41, 0xa]
+            );
+            assert_eq!(
+                std::fs::read(temp_dir.path().join("2.txt"))?,
+                vec![0x42, 0x42, 0x42, 0x42, 0xa]
+            );
+            Ok(())
+        })
+        .await?
+    }
+
+    #[tokio::test]
+    /// Test parallel download with empty file list
+    async fn test_download_multiple_parallel_empty() -> Result<()> {
+        let address = spawn_server()?.address;
+        tokio::task::spawn_blocking(move || {
+            let pz = PartialZip::new(address.join("/files/test.zip")?.as_str())?;
+            let results = pz.download_multiple_parallel(&[], 4)?;
+            assert!(results.is_empty());
+            Ok(())
+        })
+        .await?
+    }
+
+    #[tokio::test]
+    /// Test that `options()` getter returns the stored options
+    async fn test_options_getter() -> Result<()> {
+        let address = spawn_server()?.address;
+        tokio::task::spawn_blocking(move || {
+            let opts = PartialZipOptions::new().max_retries(5).max_redirects(3);
+            let pz =
+                PartialZip::new_with_options(address.join("/files/test.zip")?.as_str(), &opts)?;
+            assert_eq!(pz.options().max_retries, 5);
+            assert_eq!(pz.options().max_redirects, 3);
             Ok(())
         })
         .await?

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,3 +8,33 @@ pub fn url_is_valid(url: &str) -> bool {
         ["http", "https", "ftp", "file"].contains(&url.scheme())
     })
 }
+
+/// Matches a string against a glob pattern.
+///
+/// Supports `*` (matches any sequence of characters, including empty) and
+/// `?` (matches any single character).
+#[must_use]
+pub fn glob_match(pattern: &str, text: &str) -> bool {
+    let p: Vec<char> = pattern.chars().collect();
+    let t: Vec<char> = text.chars().collect();
+    let (plen, tlen) = (p.len(), t.len());
+
+    // dp[i][j] = pattern[0..i] matches text[0..j]
+    let mut dp = vec![vec![false; tlen + 1]; plen + 1];
+    dp[0][0] = true;
+
+    for i in 1..=plen {
+        if p[i - 1] == '*' {
+            dp[i][0] = dp[i - 1][0];
+            for j in 1..=tlen {
+                dp[i][j] = dp[i - 1][j] || dp[i][j - 1];
+            }
+        } else {
+            for j in 1..=tlen {
+                dp[i][j] = dp[i - 1][j - 1] && (p[i - 1] == '?' || p[i - 1] == t[j - 1]);
+            }
+        }
+    }
+
+    dp[plen][tlen]
+}


### PR DESCRIPTION
- Remove conv and num-traits dependencies, replace with std equivalents
- Add opt-in retry with exponential backoff via PartialZipOptions
- Add glob pattern matching (list_names_matching, download_matching, etc.)
- Add parallel multi-file downloads using std::thread::scope
- Add --json and --filter flags to the CLI list command
- Store options in PartialZip for connection reuse in parallel downloads
- Update README with library API examples and new CLI features