### PR TITLE
Optimization: preallocate buffers and reduce memory allocations

### DIFF
--- a/benches/pz_benchmark.rs
+++ b/benches/pz_benchmark.rs
@@ -8,17 +8,16 @@ use zip::ZipWriter;
 fn setup_large_zip() -> tempfile::NamedTempFile {
     let file = tempfile::NamedTempFile::new().unwrap();
     let mut zip = ZipWriter::new(file.reopen().unwrap());
-    let options = SimpleFileOptions::default()
-        .compression_method(zip::CompressionMethod::Deflated);
+    let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
 
     zip.start_file("large.bin", options).unwrap();
 
     // Generate 10 MB of high-entropy data to ensure the compressed file is large
     let mut data = vec![0u8; 1024 * 1024]; // 1 MB buffer
-    let mut seed = 0x12345678u32;
+    let mut seed = 0x1234_5678_u32;
     for _ in 0..10 {
         for byte in &mut data {
-            seed = seed.wrapping_mul(1664525).wrapping_add(1013904223);
+            seed = seed.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
             *byte = (seed >> 24) as u8;
         }
         zip.write_all(&data).unwrap();
@@ -31,8 +30,8 @@ fn setup_large_zip() -> tempfile::NamedTempFile {
 /// # Panics
 /// Can panic while creating the `PartialZip` archive
 pub fn criterion_benchmark(c: &mut Criterion) {
-    use std::path::PathBuf;
     use partialzip::partzip::PartialZip;
+    use std::path::PathBuf;
 
     c.bench_function("local file benchmark detailed list", |b| {
         b.iter(|| {
@@ -67,8 +66,11 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("local file benchmark large download", |b| {
         let large_zip_path = setup_large_zip();
         b.iter(|| {
-            let pz = PartialZip::new(&format!("file://localhost{}", large_zip_path.path().display()))
-                .expect("cannot create PartialZip in benchmark download");
+            let pz = PartialZip::new(&format!(
+                "file://localhost{}",
+                large_zip_path.path().display()
+            ))
+            .expect("cannot create PartialZip in benchmark download");
             let _download = pz.download("large.bin");
         });
     });

--- a/benches/pz_benchmark.rs
+++ b/benches/pz_benchmark.rs
@@ -1,11 +1,37 @@
 #![cfg(unix)]
 use criterion::{criterion_group, criterion_main, Criterion};
 
+use std::io::Write;
+use zip::write::SimpleFileOptions;
+use zip::ZipWriter;
+
+fn setup_large_zip() -> tempfile::NamedTempFile {
+    let file = tempfile::NamedTempFile::new().unwrap();
+    let mut zip = ZipWriter::new(file.reopen().unwrap());
+    let options = SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated);
+
+    zip.start_file("large.bin", options).unwrap();
+
+    // Generate 10 MB of high-entropy data to ensure the compressed file is large
+    let mut data = vec![0u8; 1024 * 1024]; // 1 MB buffer
+    let mut seed = 0x12345678u32;
+    for _ in 0..10 {
+        for byte in &mut data {
+            seed = seed.wrapping_mul(1664525).wrapping_add(1013904223);
+            *byte = (seed >> 24) as u8;
+        }
+        zip.write_all(&data).unwrap();
+    }
+    zip.finish().unwrap();
+
+    file
+}
+
 /// # Panics
 /// Can panic while creating the `PartialZip` archive
 pub fn criterion_benchmark(c: &mut Criterion) {
     use std::path::PathBuf;
-
     use partialzip::partzip::PartialZip;
 
     c.bench_function("local file benchmark detailed list", |b| {
@@ -35,6 +61,15 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             let pz = PartialZip::new(&format!("file://localhost{}", d.display()))
                 .expect("cannot create PartialZip in benchmark download");
             let _download = pz.download("1.txt");
+        });
+    });
+
+    c.bench_function("local file benchmark large download", |b| {
+        let large_zip_path = setup_large_zip();
+        b.iter(|| {
+            let pz = PartialZip::new(&format!("file://localhost{}", large_zip_path.path().display()))
+                .expect("cannot create PartialZip in benchmark download");
+            let _download = pz.download("large.bin");
         });
     });
 }

--- a/src/partzip.rs
+++ b/src/partzip.rs
@@ -354,7 +354,8 @@ impl PartialZip {
     /// # Errors
     /// Will return a [`PartialZipError`] depending on what happened
     pub fn download(&self, filename: &str) -> Result<Vec<u8>, PartialZipError> {
-        let size = self.archive.borrow_mut().by_name(filename)?.size() as usize;
+        let size = usize::try_from(self.archive.borrow_mut().by_name(filename)?.size())
+            .unwrap_or(usize::MAX);
         let mut content: Vec<u8> = Vec::with_capacity(size);
         self.download_to_write(filename, &mut content)?;
         Ok(content)
@@ -421,7 +422,8 @@ impl PartialZip {
     /// Will return a [`PartialZipError`] depending on what happened
     #[cfg(feature = "progressbar")]
     pub fn download_with_progressbar(&self, filename: &str) -> Result<Vec<u8>, PartialZipError> {
-        let size = self.archive.borrow_mut().by_name(filename)?.size() as usize;
+        let size = usize::try_from(self.archive.borrow_mut().by_name(filename)?.size())
+            .unwrap_or(usize::MAX);
         let mut content: Vec<u8> = Vec::with_capacity(size);
         self.download_to_write_with_progressbar(filename, &mut content)?;
         Ok(content)
@@ -938,10 +940,18 @@ impl io::Read for PartialReader {
                 let mut transfer = self.easy.transfer();
                 transfer.write_function(|data| {
                     log::trace!("transferred {:x} bytes", data.len());
-                    let len = std::cmp::min(data.len(), buf.len() - written);
-                    if len > 0 {
-                        buf[written..written + len].copy_from_slice(&data[..len]);
-                        written += len;
+                    let remaining = buf.len().saturating_sub(written);
+                    if data.len() > remaining {
+                        log::warn!(
+                            "Received {} bytes but only {} bytes remain in destination buffer; aborting transfer",
+                            data.len(),
+                            remaining
+                        );
+                        return Ok(0);
+                    }
+                    if !data.is_empty() {
+                        buf[written..written + data.len()].copy_from_slice(data);
+                        written += data.len();
                     }
                     Ok(data.len())
                 })?;

--- a/src/partzip.rs
+++ b/src/partzip.rs
@@ -865,6 +865,7 @@ impl PartialReader {
 }
 
 impl io::Read for PartialReader {
+    #[allow(clippy::too_many_lines)]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         const MAX_RETRY_DELAY: Duration = Duration::from_secs(60);
         log::trace!(

--- a/src/partzip.rs
+++ b/src/partzip.rs
@@ -354,7 +354,8 @@ impl PartialZip {
     /// # Errors
     /// Will return a [`PartialZipError`] depending on what happened
     pub fn download(&self, filename: &str) -> Result<Vec<u8>, PartialZipError> {
-        let mut content: Vec<u8> = Vec::new();
+        let size = self.archive.borrow_mut().by_name(filename)?.size() as usize;
+        let mut content: Vec<u8> = Vec::with_capacity(size);
         self.download_to_write(filename, &mut content)?;
         Ok(content)
     }
@@ -420,7 +421,8 @@ impl PartialZip {
     /// Will return a [`PartialZipError`] depending on what happened
     #[cfg(feature = "progressbar")]
     pub fn download_with_progressbar(&self, filename: &str) -> Result<Vec<u8>, PartialZipError> {
-        let mut content: Vec<u8> = Vec::new();
+        let size = self.archive.borrow_mut().by_name(filename)?.size() as usize;
+        let mut content: Vec<u8> = Vec::with_capacity(size);
         self.download_to_write_with_progressbar(filename, &mut content)?;
         Ok(content)
     }
@@ -931,12 +933,16 @@ impl io::Read for PartialReader {
                 std::thread::sleep(delay);
             }
 
-            let mut content: Vec<u8> = Vec::new();
+            let mut written = 0;
             {
                 let mut transfer = self.easy.transfer();
                 transfer.write_function(|data| {
                     log::trace!("transferred {:x} bytes", data.len());
-                    content.extend_from_slice(data);
+                    let len = std::cmp::min(data.len(), buf.len() - written);
+                    if len > 0 {
+                        buf[written..written + len].copy_from_slice(&data[..len]);
+                        written += len;
+                    }
                     Ok(data.len())
                 })?;
 
@@ -950,7 +956,7 @@ impl io::Read for PartialReader {
                 }
             }
 
-            let n = io::Read::read(&mut content.as_slice(), buf)?;
+            let n = written;
             // new position = position + read amount;
             self.pos = self.pos.checked_add(n as u64).ok_or_else(|| {
                 std::io::Error::new(


### PR DESCRIPTION
Improves performance for larger operations with files/archives; also adds a benchmark for 10 MB files to test this performance

Benchmark (file.bin; 1,273,671 bytes):
Old:
```
        5.47 real         2.52 user         2.94 sys
            69484544  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
                5022  page reclaims
                  84  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
                   6  voluntary context switches
                 110  involuntary context switches
         53233349424  instructions retired
         17611577028  cycles elapsed
            63046136  peak memory footprint
```
New:
```
        4.13 real         1.36 user         2.75 sys
            67256320  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
                4954  page reclaims
                  11  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
                   3  voluntary context switches
                 233  involuntary context switches
         43397266707  instructions retired
         13275851643  cycles elapsed
            60785168  peak memory footprint
```



Original 3 benchmarks show pretty similar times, with the new 10 MB benchmark showing the following:
* Old: `4.9226 ms`
* New: `3.3946 ms`

Haven't been able to fully test this, but all tests pass and it seems to work on a basic level (checking extracted file's SHA-256 hash)